### PR TITLE
✨ バックエンドとフロント側での疎通確認用ページを作成

### DIFF
--- a/README.me
+++ b/README.me
@@ -20,6 +20,7 @@
 2.3 npm run dev
 
 - 起動確認: http://localhost:3000/
+-http://localhost:3000/api-testでDjangoとの疎通確認が可能
 
 ### 3. バックエンド（Django）サーバー立ち上げ
 3.1 cd backend

--- a/backend/secure_storage/settings.py
+++ b/backend/secure_storage/settings.py
@@ -37,10 +37,12 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -120,3 +122,11 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# CORS settings
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+]
+
+CORS_ALLOW_ALL_ORIGINS = True  # 開発用（本番ではFalseに）

--- a/backend/secure_storage/urls.py
+++ b/backend/secure_storage/urls.py
@@ -16,7 +16,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from . import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/health/', views.health_check, name='health_check'),
+    path('api/test/', views.test_api, name='test_api'),
 ]

--- a/backend/secure_storage/views.py
+++ b/backend/secure_storage/views.py
@@ -1,0 +1,31 @@
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+import json
+
+@csrf_exempt
+@require_http_methods(["GET"])
+def health_check(request):
+    """フロントエンドとの疎通確認用API"""
+    return JsonResponse({
+        'message': 'Hello from Django!',
+        'status': 'success',
+        'timestamp': '2024-01-01 12:00:00'
+    })
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def test_api(request):
+    """POSTリクエストのテスト用API"""
+    try:
+        data = json.loads(request.body)
+        return JsonResponse({
+            'message': f'Received: {data.get("message", "No message")}',
+            'status': 'success',
+            'received_data': data
+        })
+    except json.JSONDecodeError:
+        return JsonResponse({
+            'message': 'Invalid JSON data',
+            'status': 'error'
+        }, status=400) 

--- a/frontend/src/app/api-test/page.tsx
+++ b/frontend/src/app/api-test/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function ApiTestPage() {
+  const [healthResponse, setHealthResponse] = useState<{
+    error?: string;
+  } | null>(null);
+  const [testResponse, setTestResponse] = useState<{ error?: string } | null>(
+    null
+  );
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('Hello from Next.js!');
+
+  const testHealthCheck = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('http://127.0.0.1:8000/api/health/');
+      const data = await response.json();
+      setHealthResponse(data);
+    } catch (error) {
+      setHealthResponse({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const testPostApi = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('http://127.0.0.1:8000/api/test/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ message }),
+      });
+      const data = await response.json();
+      setTestResponse(data);
+    } catch (error) {
+      setTestResponse({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className='min-h-screen bg-gray-100 py-8'>
+      <div className='max-w-4xl mx-auto px-4'>
+        <h1 className='text-3xl font-bold text-center mb-8'>
+          Django API 疎通確認
+        </h1>
+
+        <div className='grid md:grid-cols-2 gap-8'>
+          {/* Health Check */}
+          <div className='bg-white p-6 rounded-lg shadow-md'>
+            <h2 className='text-xl font-semibold mb-4'>Health Check (GET)</h2>
+            <button
+              onClick={testHealthCheck}
+              disabled={loading}
+              className='bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50'
+            >
+              {loading ? 'Loading...' : 'Test Health Check'}
+            </button>
+
+            {healthResponse && (
+              <div className='mt-4'>
+                <h3 className='font-semibold mb-2'>Response:</h3>
+                <pre className='bg-gray-100 p-3 rounded text-sm overflow-auto'>
+                  {JSON.stringify(healthResponse, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+
+          {/* Test API */}
+          <div className='bg-white p-6 rounded-lg shadow-md'>
+            <h2 className='text-xl font-semibold mb-4'>Test API (POST)</h2>
+            <div className='mb-4'>
+              <label className='block text-sm font-medium mb-2'>Message:</label>
+              <input
+                type='text'
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                className='w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500'
+              />
+            </div>
+            <button
+              onClick={testPostApi}
+              disabled={loading}
+              className='bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50'
+            >
+              {loading ? 'Loading...' : 'Test POST API'}
+            </button>
+
+            {testResponse && (
+              <div className='mt-4'>
+                <h3 className='font-semibold mb-2'>Response:</h3>
+                <pre className='bg-gray-100 p-3 rounded text-sm overflow-auto'>
+                  {JSON.stringify(testResponse, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Status */}
+        <div className='mt-8 bg-white p-6 rounded-lg shadow-md'>
+          <h2 className='text-xl font-semibold mb-4'>接続状況</h2>
+          <div className='space-y-2'>
+            <div className='flex items-center'>
+              <div className='w-3 h-3 bg-green-500 rounded-full mr-3'></div>
+              <span>Next.js: http://localhost:3000</span>
+            </div>
+            <div className='flex items-center'>
+              <div className='w-3 h-3 bg-blue-500 rounded-full mr-3'></div>
+              <span>Django: http://127.0.0.1:8000</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
取り急ぎ環境構築と、test用にバックエンドとフロント側の疎通確認用ページつくりました。この実装を参考に今後Django側でのエンドポイント作成やNext.jsのAPIリクエストをしていただければと思います
<img width="1301" height="765" alt="image" src="https://github.com/user-attachments/assets/546f42b5-c948-416c-9369-130346fc98d9" />

もろもろの環境構築方法はread.meに記載しているのでそちらをご確認ください。
取り急ぎこのプルリクエストはとりあえずマージしときます！